### PR TITLE
Update metric and log storage layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-`main.py` orchestrates training and evaluation, while `dataset.py` handles device selection and dataset wiring. Model components reside in `models/` and reusable blocks in `layers/`. Training logic and experiment configs live in `trainers/`, with utilities in `utils/`. Raw SMD text files remain in `ServerMachineDataset/`; processed artifacts, checkpoints, metrics, and logs are routed to `results/`, `checkpoints/`, and `logs/` by run ID. Shell presets for repeatable experiments sit in `scripts/`.
+`main.py` orchestrates training and evaluation, while `dataset.py` handles device selection and dataset wiring. Model components reside in `models/` and reusable blocks in `layers/`. Training logic and experiment configs live in `trainers/`, with utilities in `utils/`. Raw SMD text files remain in `ServerMachineDataset/`; processed artifacts land under `results/`, checkpoints in `checkpoints/`, and aggregated logs in `logs/` with model-scoped fan-out. Shell presets for repeatable experiments sit in `scripts/`.
 
 ## Build, Test, and Development Commands
 Create the recommended environment and install dependencies before running anything:
@@ -16,7 +16,7 @@ Train the default Transformer with `python main.py --model Transformer --dataset
 Follow PEP 8 with 4-space indentation, limit modules to clear responsibilities, and keep functions under 80–100 lines. Preserve existing type hints and dataclass-style config patterns; add docstrings when behaviour is non-obvious. Use snake_case for Python symbols and CLI flags, and kebab-case for shell script names. Before sending a PR, ensure files stay formatted by your editor (no trailing spaces) and `python -m compileall .` passes when feasible.
 
 ## Testing Guidelines
-There is no unit-test suite yet; validation is performed through end-to-end evaluation. Always finish a training run with `python main.py --mode test --pretrained_run <run_id>` and review the emitted JSON under `logs/<machine_id>/<model>/<run_id>_metrics.json`. Track the deployment-ready `precision`/`recall`/`f1` (EMA adaptive threshold + segment adjusted), and capture `point_f1` / `best_f1` deltas alongside the summary stored in `results/`. When reporting diagnostics, attach the relevant run ID together with the active `threshold_alpha`, `threshold_k`, and `anomaly_ratio` values.
+There is no unit-test suite yet; validation is performed through end-to-end evaluation. Always finish a training run with `python main.py --mode test --pretrained_run <run_id>` and review the appended block under `logs/<model>/metrics.txt`. Track the deployment-ready `precision`/`recall`/`f1` (EMA adaptive threshold + segment adjusted), and capture `point_f1` / `best_f1` deltas alongside the summary stored in `results/<model>/summary.txt`. When reporting diagnostics, attach the relevant run ID together with the active `threshold_alpha`, `threshold_k`, and `anomaly_ratio` values.
 
 ## Commit & Pull Request Guidelines
 Git history favours concise, descriptive commit subjects (often in Simplified Chinese, e.g., “修复配置序列化与 Transformer 损失函数”). Keep commits focused and reference affected modules when helpful. Open feature and fix branches from `dev`; reserve `main` for validated releases. A pull request should: summarise motivation and outcomes, list key commands used, link related issues, and paste the latest evaluation metrics or screenshots of result dashboards. Tag reviewers familiar with the touched model family and note any follow-up debt.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ python main.py \
   --normalize
 ```
 
-训练日志将显示在终端，并同时写入 `logs/<machine_id>/<模型名称>/<run_id>_metrics.json`。模型与指标存放于：
+训练日志将显示在终端，并同时追加到 `logs/<模型名称>/metrics.txt`（每次训练以单独的 `=` 行分隔）。模型与指标存放于：
 - `checkpoints/<模型名称>.pt`
-- `results/<machine_id>/<模型名称>/<run_id>/summary.json`
+- `results/<模型名称>/summary.txt`
+- `results/<模型名称>/<run_id>/`
 
 
 ## 测试/评估
@@ -154,7 +155,7 @@ python main.py \
   --normalize
 ```
 
-Results are saved under `results/<machine_id>/<run_id>/summary.json`, checkpoints under `checkpoints/<model_name>.pt`.
+Results are appended to `results/<model_name>/summary.txt` (each session separated by `=`), while checkpoints remain under `checkpoints/<model_name>.pt`.
 
 ### Evaluation
 

--- a/dataset.py
+++ b/dataset.py
@@ -204,9 +204,14 @@ def summarize_run(
         "metrics": metrics,
     }
 
-    summary_path = output_dir / "summary.json"
+    summary_path = output_dir / "summary.txt"
+    summary_json = json.dumps(summary, ensure_ascii=False, indent=2)
+    separator_needed = summary_path.exists() and summary_path.stat().st_size > 0
 
-    with summary_path.open("w", encoding="utf-8") as f:
-        json.dump(summary, f, ensure_ascii=False, indent=2)
+    with summary_path.open("a", encoding="utf-8") as f:
+        if separator_needed:
+            f.write("=\n")
+        f.write(summary_json)
+        f.write("\n")
 
 


### PR DESCRIPTION
## Summary
- aggregate training summaries into `results/<model_name>/summary.txt` with `=` separators
- append evaluation metrics to `logs/<model_name>/metrics.txt` across sessions
- refresh helpers and docs to reflect the new storage structure

## Testing
- python -m compileall trainers dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d03d98888324bc5c72d341d2bab0