### PR TITLE
Add machine-1 stacked training script and warm-start option

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--results_dir", type=str, default="results")
     parser.add_argument("--checkpoints_dir", type=str, default="checkpoints")
     parser.add_argument("--logs_dir", type=str, default="logs")
+    parser.add_argument(
+        "--init_checkpoint",
+        type=str,
+        default=None,
+        help="预训练权重路径，用于继续训练",
+    )
 
     return parser.parse_args()
 
@@ -55,6 +61,12 @@ def main() -> None:
 
     device = get_device(args.device)
     extra_params = json.loads(args.extra_params) if args.extra_params else {}
+
+    init_checkpoint = None
+    if args.init_checkpoint:
+        init_checkpoint = Path(args.init_checkpoint)
+        if not init_checkpoint.is_absolute():
+            init_checkpoint = (project_root / init_checkpoint).resolve()
 
     config = ExperimentConfig(
         machine_id=args.dataset,
@@ -85,6 +97,7 @@ def main() -> None:
         n_heads=args.n_heads,
         num_layers=args.num_layers,
         dropout=args.dropout,
+        init_checkpoint=init_checkpoint,
     )
 
     trainer = PipelineTrainer(config)

--- a/scripts/transformer-machine-1.sh
+++ b/scripts/transformer-machine-1.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Transformer 跨 machine-1 系列堆叠训练示例
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+cd "${PROJECT_ROOT}"
+
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+CHECKPOINT_DIR="${PROJECT_ROOT}/checkpoints"
+mkdir -p "${CHECKPOINT_DIR}"
+
+MACHINES=(
+  machine-1-1
+  machine-1-2
+  machine-1-3
+)
+
+INIT_CKPT=""
+
+for MACHINE in "${MACHINES[@]}"; do
+  echo "[INFO] Training Transformer on ${MACHINE}"
+
+  RUN_ID="${MACHINE}-${TIMESTAMP}"
+  CKPT_TAG="Transformer-${MACHINE}-${TIMESTAMP}.pt"
+
+  CMD=(
+    python main.py
+    --model Transformer
+    --dataset "${MACHINE}"
+    --window_length 100
+    --d_model 192
+    --d_ff 320
+    --n_heads 4
+    --num_layers 4
+    --dropout 0.2
+    --batch_size 256
+    --learning_rate 5e-4
+    --max_epoch 25
+    --anomaly_ratio 0.2
+    --normalize
+    --stride 1
+    --run_id "${RUN_ID}"
+  )
+
+  if [[ -n "${INIT_CKPT}" ]]; then
+    CMD+=(--init_checkpoint "${INIT_CKPT}")
+  fi
+
+  "${CMD[@]}"
+
+  if [[ ! -f "${CHECKPOINT_DIR}/Transformer.pt" ]]; then
+    echo "[ERROR] Missing checkpoint after training ${MACHINE}" >&2
+    exit 1
+  fi
+
+  cp "${CHECKPOINT_DIR}/Transformer.pt" "${CHECKPOINT_DIR}/${CKPT_TAG}"
+  INIT_CKPT="checkpoints/${CKPT_TAG}"
+done
+
+echo "[INFO] Finished stacked training across machine-1-* datasets."


### PR DESCRIPTION
## Summary
- add an --init_checkpoint flag to warm start training runs from an existing checkpoint
- propagate the optional checkpoint into the pipeline config and metric summary for traceability
- add a transformer-machine-1.sh helper to stack-train machine-1-1/2/3 with cascading checkpoints

## Testing
- bash -n scripts/transformer-machine-1.sh

------
https://chatgpt.com/codex/tasks/task_e_68e0dfb279ec83249106ab592fa6e3cb